### PR TITLE
Allow ModuleDetector for at least a typo in words

### DIFF
--- a/WhisperAPI/WhisperAPI.Tests/Integration/SuggestionsControllerTest.cs
+++ b/WhisperAPI/WhisperAPI.Tests/Integration/SuggestionsControllerTest.cs
@@ -159,7 +159,7 @@ namespace WhisperAPI.Tests.Integration
 
             // Customer says: I need help with CoveoSearch API
             searchQuery = SearchQueryBuilder.Build
-                .WithQuery("I need help with CoveoSearch API")
+                .WithQuery("I necessitate help with CoveoSearch API")
                 .WithChatKey(searchQuery.ChatKey)
                 .Instance;
 

--- a/WhisperAPI/WhisperAPI.Tests/Unit/MegaGenial/ModuleDetectorTest.cs
+++ b/WhisperAPI/WhisperAPI.Tests/Unit/MegaGenial/ModuleDetectorTest.cs
@@ -21,7 +21,7 @@ namespace WhisperAPI.Tests.Unit.MegaGenial
         {
             var detector = new ModuleDetector();
             var modules = detector.DetectModuleList("J'observe des fils avec des lumières et des étoiles");
-            Assert.Contains((Module.WireComplicated, 1), modules);
+            Assert.Contains((Module.WireComplicated, 3), modules);
         }
 
         [Test]
@@ -57,6 +57,15 @@ namespace WhisperAPI.Tests.Unit.MegaGenial
         {
             var detector = new ModuleDetector();
             var modules = detector.DetectModuleList("Je vois un écran avec des chiffres");
+            Assert.Contains((Module.Memory, 2), modules);
+        }
+
+        [Test]
+        [TestCase]
+        public void WhenSentenceIsDescribingAMemoryModuleWithTyposThenSaidModuleIsReturned()
+        {
+            var detector = new ModuleDetector();
+            var modules = detector.DetectModuleList("Je vois un ecran avec des chifre");
             Assert.Contains((Module.Memory, 1), modules);
         }
 
@@ -69,6 +78,26 @@ namespace WhisperAPI.Tests.Unit.MegaGenial
             Assert.Contains((Module.WireComplicated, 1), modules);
             Assert.Contains((Module.WireSequence, 1), modules);
             Assert.Contains((Module.WireSimple, 1), modules);
+        }
+
+        [Test]
+        [TestCase]
+        public void WhenSentenceIsDescribingManyModulesWithATypoThenSaidModulesAreReturned()
+        {
+            var detector = new ModuleDetector();
+            var modules = detector.DetectModuleList("J'aime les fisl");
+            Assert.Contains((Module.WireComplicated, 1), modules);
+            Assert.Contains((Module.WireSequence, 1), modules);
+            Assert.Contains((Module.WireSimple, 1), modules);
+        }
+
+        [Test]
+        [TestCase]
+        public void WhenSentenceIsDescribingManyModulesWithAMajorTypoThenNoModulesAreReturned()
+        {
+            var detector = new ModuleDetector();
+            var modules = detector.DetectModuleList("J'aime les filles");
+            Assert.IsEmpty(modules);
         }
     }
 }

--- a/WhisperAPI/WhisperAPI.Tests/Unit/MegaGenial/WordDistanceTest.cs
+++ b/WhisperAPI/WhisperAPI.Tests/Unit/MegaGenial/WordDistanceTest.cs
@@ -1,0 +1,59 @@
+﻿using NUnit.Framework;
+using WhisperAPI.Models.MegaGenial;
+
+namespace WhisperAPI.Tests.Unit.MegaGenial
+{
+    [TestFixture]
+    public class WordDistanceTest
+    {
+        [Test]
+        [TestCase]
+        public void WhenASpaceTypoIsMadeThenASmallDistanceIsReturned()
+        {
+            var word1 = "LeMot";
+            var word2 = "Le Mot";
+            var distance = DistanceCalculator.GetDistance(DistanceCalculator.ConvertWord(word1), DistanceCalculator.ConvertWord(word2));
+            Assert.AreEqual(1, distance);
+        }
+
+        [Test]
+        [TestCase]
+        public void WhenALetterTypoIsMadeThenASmallDistanceIsReturned()
+        {
+            var word1 = "LeMot";
+            var word2 = "LeMor";
+            var distance = DistanceCalculator.GetDistance(DistanceCalculator.ConvertWord(word1), DistanceCalculator.ConvertWord(word2));
+            Assert.AreEqual(1, distance);
+        }
+
+        [Test]
+        [TestCase]
+        public void WhenAnInversionTypoIsMadeThenASmallDistanceIsReturned()
+        {
+            var word1 = "LeMot";
+            var word2 = "LeMto";
+            var distance = DistanceCalculator.GetDistance(DistanceCalculator.ConvertWord(word1), DistanceCalculator.ConvertWord(word2));
+            Assert.AreEqual(1, distance);
+        }
+
+        [Test]
+        [TestCase]
+        public void WhenABigTypoIsMadeThenAMaxDistanceIsReturned()
+        {
+            var word1 = "LeMot";
+            var word2 = "LeMto43";
+            var distance = DistanceCalculator.GetDistance(DistanceCalculator.ConvertWord(word1), DistanceCalculator.ConvertWord(word2));
+            Assert.AreEqual(int.MaxValue, distance);
+        }
+
+        [Test]
+        [TestCase]
+        public void WhenNoTypeAreMadeThenANullDistanceIsReturned()
+        {
+            var word1 = "LeMot";
+            var word2 = "LeMot";
+            var distance = DistanceCalculator.GetDistance(DistanceCalculator.ConvertWord(word1), DistanceCalculator.ConvertWord(word2));
+            Assert.AreEqual(0, distance);
+        }
+    }
+}

--- a/WhisperAPI/WhisperAPI/Models/MegaGenial/DistanceCalculator.cs
+++ b/WhisperAPI/WhisperAPI/Models/MegaGenial/DistanceCalculator.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Linq;
+
+namespace WhisperAPI.Models.MegaGenial
+{
+    public class DistanceCalculator
+    {
+        public static int[] ConvertWord(string word)
+        {
+            return word.ToCharArray().Select(n => Convert.ToInt32(n)).ToArray();
+        }
+
+        public static int GetDistance(int[] word1, int[] word2)
+        {
+            return DamerauLevenshteinDistance(word1, word2, 2);
+        }
+
+        private static void Swap<T>(ref T arg1, ref T arg2)
+        {
+            T temp = arg1;
+            arg1 = arg2;
+            arg2 = temp;
+        }
+
+        private static int DamerauLevenshteinDistance(int[] source, int[] target, int threshold)
+        {
+
+            int length1 = source.Length;
+            int length2 = target.Length;
+
+            // Return trivial case - difference in string lengths exceeds threshhold
+            if (Math.Abs(length1 - length2) > threshold) { return int.MaxValue; }
+
+            // Ensure arrays [i] / length1 use shorter length 
+            if (length1 > length2)
+            {
+                Swap(ref target, ref source);
+                Swap(ref length1, ref length2);
+            }
+
+            int maxi = length1;
+            int maxj = length2;
+
+            int[] dCurrent = new int[maxi + 1];
+            int[] dMinus1 = new int[maxi + 1];
+            int[] dMinus2 = new int[maxi + 1];
+            int[] dSwap;
+
+            for (int i = 0; i <= maxi; i++) { dCurrent[i] = i; }
+
+            int jm1 = 0, im1 = 0, im2 = -1;
+
+            for (int j = 1; j <= maxj; j++)
+            {
+
+                // Rotate
+                dSwap = dMinus2;
+                dMinus2 = dMinus1;
+                dMinus1 = dCurrent;
+                dCurrent = dSwap;
+
+                // Initialize
+                int minDistance = int.MaxValue;
+                dCurrent[0] = j;
+                im1 = 0;
+                im2 = -1;
+
+                for (int i = 1; i <= maxi; i++)
+                {
+
+                    int cost = source[im1] == target[jm1] ? 0 : 1;
+
+                    int del = dCurrent[im1] + 1;
+                    int ins = dMinus1[i] + 1;
+                    int sub = dMinus1[im1] + cost;
+
+                    //Fastest execution for min value of 3 integers
+                    int min = (del > ins) ? (ins > sub ? sub : ins) : (del > sub ? sub : del);
+
+                    if (i > 1 && j > 1 && source[im2] == target[jm1] && source[im1] == target[j - 2])
+                        min = Math.Min(min, dMinus2[im2] + cost);
+
+                    dCurrent[i] = min;
+                    if (min < minDistance) { minDistance = min; }
+                    im1++;
+                    im2++;
+                }
+                jm1++;
+                if (minDistance > threshold) { return int.MaxValue; }
+            }
+
+            int result = dCurrent[maxi];
+            return (result > threshold) ? int.MaxValue : result;
+        }
+    }
+}

--- a/WhisperAPI/WhisperAPI/Models/MegaGenial/ModuleDetector.cs
+++ b/WhisperAPI/WhisperAPI/Models/MegaGenial/ModuleDetector.cs
@@ -6,11 +6,12 @@ namespace WhisperAPI.Models.MegaGenial
 {
     public class ModuleDetector
     {
+        private static readonly Dictionary<Module, List<int[]>> _intVocabularyByModule = new Dictionary<Module, List<int[]>>();
         private static readonly Dictionary<Module, string> _vocabularyByModule = new Dictionary<Module, string>
         {
             { Module.Keypad, "dessins boutons quatres 4" },
             { Module.Maze, "quadrillé triangle rouge cercles verts point blanc 6 par six maze labyrinthe" },
-            { Module.Memory, "mémoire memoire quatres chiffres 1234 gros nombres boutons premier deuxième troisième quatrième deuxieme troisieme quatrieme" },
+            { Module.Memory, "mémoire memoire quatres chiffres écran ecran 1234 gros nombres boutons premier deuxième troisième quatrième deuxieme troisieme quatrieme" },
             { Module.Password, "lettres submit 5 cinq flèches fleches tableau vert haut bas mot de passe password premier deuxième troisième quatrième cinquième deuxieme troisieme quatrieme cinquieme" },
             { Module.SimonSays, "simon says 4 carrés jaune bleu rouge vert clignote clignotant flash quatre" },
             { Module.WhosFirst, "mots étiquettes etiquettes boutons 6 six 2 colonnes rangées rangees deux they are blank read red you your you're their they're empty reed leeds there display says no lead hold on you are c c see ready first no blank nothing yes what u h h h left right middle okay wait press you you are your you're u r u uh huh staccato what question done next hold sure like whos who's" },
@@ -19,6 +20,17 @@ namespace WhisperAPI.Models.MegaGenial
             { Module.WireSimple, "3 trois 4 quatre 5 cinq 6 six couleurs fils simple premier deuxième troisième quatrième cinquième sixième deuxieme troisieme quatrieme cinquieme sixieme coupé coupe couper horizontal horizontaux" },
             { Module.None, string.Empty },
         };
+
+        public ModuleDetector()
+        {
+            if (!_intVocabularyByModule.Any())
+            {
+                foreach (var (module, vocabulary) in _vocabularyByModule)
+                {
+                    _intVocabularyByModule.Add(module, vocabulary.Split(' ').Select(x => DistanceCalculator.ConvertWord(x)).ToList());
+                }
+            }
+        }
 
         public List<(Module, int)> DetectModuleList(string textContent)
         {
@@ -50,13 +62,36 @@ namespace WhisperAPI.Models.MegaGenial
             var score = 0;
             foreach (var word in textContent.ToLower().Split(" "))
             {
-                if (_vocabularyByModule[module].Split(" ").Contains(word))
+                if (word.Length <= 3 && this.IsSimpleWordInModule(_vocabularyByModule[module], word))
+                {
+                    score += 1;
+                }
+                else if (word.Length > 3 && this.IsComplexWordInModule(_intVocabularyByModule[module], word))
                 {
                     score += 1;
                 }
             }
 
             return score;
+        }
+
+        private bool IsSimpleWordInModule(string vocabulary, string word)
+        {
+            return vocabulary.Split(" ").Contains(word);
+        }
+
+        private bool IsComplexWordInModule(List<int[]> intVocabulary, string word)
+        {
+            var intWord = DistanceCalculator.ConvertWord(word);
+            foreach (var moduleWord in intVocabulary)
+            {
+                if (DistanceCalculator.GetDistance(intWord, moduleWord) <= 1)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
Pour les mots de plus de 3 lettres, on accepte une typo en utilisant la distance Damerau-Levenshtein entre les mots